### PR TITLE
Add modularity

### DIFF
--- a/markov_clustering/__init__.py
+++ b/markov_clustering/__init__.py
@@ -1,4 +1,5 @@
 from .mcl import *
+from .modularity import *
 
 try:
     from .drawing import *

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -62,8 +62,8 @@ def modularity(matrix, result):
     else:
         expected = lambda i,j : ( matrix_2[i,:].sum()*matrix[:,j].sum() )
     
-    indeces = np.array(result.nonzero())
-    Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indeces.T )/m
+    indices = np.array(result.nonzero())
+    Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indices.T if i != j )/m
     
     return Q
     

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -1,3 +1,7 @@
+"""
+Computation of the modularity of a clustering
+"""
+
 import numpy as np
 from fractions import Fraction
 from itertools import permutations
@@ -41,7 +45,7 @@ def convert_to_adjacency_matrix(matrix):
 def delta_matrix(matrix, clusters):
     """
     Compute delta matrix where delta[i,j]=1 if i and j belong
-    to same cluster and i=!j
+    to same cluster and i!=j
     
     :param matrix: The adjacency matrix
     :param clusters: The clusters returned by get_clusters

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -4,65 +4,66 @@ from scipy.sparse import isspmatrix, dok_matrix, find
 from .mcl import sparse_allclose
 
 def is_undirected(matrix):
-	"""
-	Determine if the matrix reprensents a directed graph
+    """
+    Determine if the matrix reprensents a directed graph
 
-	:param matrix: The matrix to tested
-	:returns: boolean
-	"""
-	if isspmatrix(matrix):
-		return sparse_allclose(matrix, matrix.transpose())
-	
-	return np.allclose(matrix, matrix.T)
+    :param matrix: The matrix to tested
+    :returns: boolean
+    """
+    if isspmatrix(matrix):
+        return sparse_allclose(matrix, matrix.transpose())
+    
+    return np.allclose(matrix, matrix.T)
 
 
 def convert_to_adjacency_matrix(matrix):
-	"""
-	Converts transition matrix into adjacency matrix
+    """
+    Converts transition matrix into adjacency matrix
 
-	:param matrix: The matrix to be converted
-	:returns: adjacency matrix
-	"""
-	for i in range(matrix.shape[0]):
-		
-		if isspmatrix(matrix):
-			col = find(matrix[:,i])[2]
-		else:
-			col = matrix[:,i]
+    :param matrix: The matrix to be converted
+    :returns: adjacency matrix
+    """
+    for i in range(matrix.shape[0]):
+        
+        if isspmatrix(matrix):
+            col = find(matrix[:,i])[2]
+        else:
+            col = matrix[:,i]
 
-		coeff = max( Fraction(c).limit_denominator().denominator for c in col )
-		matrix[:,i] *= coeff
+        coeff = max( Fraction(c).limit_denominator().denominator for c in col )
+        matrix[:,i] *= coeff
 
-	return matrix
+    return matrix
 
 
 def modularity(matrix, result):
-	"""
-	Compute the modularity
+    """
+    Compute the modularity
 
-	:param matrix: The adjacency matrix
-	:param result: The matrix result of mcl
-	:returns: modularity value
-	"""
-	matrix = convert_to_adjacency_matrix(matrix)
+    :param matrix: The adjacency matrix
+    :param result: The matrix result of mcl
+    :returns: modularity value
+    """
+    matrix = convert_to_adjacency_matrix(matrix)
 
-	# makes sure result[i,j]>0 if i and j belong to the same cluster
-	result = result + result.T
-	
-	m = matrix.sum()
+    # makes sure result[i,j]>0 if i and j belong to the same cluster
+    result = result + result.T
+    
+    m = matrix.sum()
 
-	if isspmatrix(matrix):
-		matrix_2 = matrix.tocsr(copy=True)
-	else :
-		matrix_2 = matrix
+    if isspmatrix(matrix):
+        matrix_2 = matrix.tocsr(copy=True)
+    else :
+        matrix_2 = matrix
 
-	if is_undirected(matrix):
-		expected = lambda i,j : (( matrix_2[i,:].sum() + matrix[:,i].sum() )*
-								 ( matrix[:,j].sum() + matrix_2[j,:].sum() ))
-	else:
-		expected = lambda i,j : ( matrix_2[i,:].sum()*matrix[:,j].sum() )
-	
-	indeces = np.array(result.nonzero())
-	Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indeces.T )/m
-	
-	return Q
+    if is_undirected(matrix):
+        expected = lambda i,j : (( matrix_2[i,:].sum() + matrix[:,i].sum() )*
+                                 ( matrix[:,j].sum() + matrix_2[j,:].sum() ))
+    else:
+        expected = lambda i,j : ( matrix_2[i,:].sum()*matrix[:,j].sum() )
+    
+    indeces = np.array(result.nonzero())
+    Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indeces.T )/m
+    
+    return Q
+    

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -39,13 +39,21 @@ def convert_to_adjacency_matrix(matrix):
 
 
 def delta_matrix(matrix, clusters):
+     """
+    Compute delta matrix where delta[i,j]=1 if i and j belong
+    to same cluster and i=!j
+
+    :param matrix: The adjacency matrix
+    :param clusters: The clusters returned by get_clusters
+    :returns: delta matrix
+    """
     if isspmatrix(matrix):
         delta = dok_matrix(matrix.shape)
     else :
         delta = np.zeros(matrix.shape)
 
     for i in clusters :
-        for j in combinations(l, 2):
+        for j in combinations(i, 2):
             delta[j] = 1
 
     return delta
@@ -60,8 +68,6 @@ def modularity(matrix, clusters):
     :returns: modularity value
     """
     matrix = convert_to_adjacency_matrix(matrix)
-    delta  = delta_matrix(clusters)
-    
     m = matrix.sum()
 
     if isspmatrix(matrix):
@@ -75,7 +81,9 @@ def modularity(matrix, clusters):
     else:
         expected = lambda i,j : ( matrix_2[i,:].sum()*matrix[:,j].sum() )
     
+    delta   = delta_matrix(clusters)
     indices = np.array(delta.nonzero())
+    
     Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indices.T )/m
     
     return Q

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -45,6 +45,10 @@ def modularity(matrix, result):
 	:returns: modularity value
 	"""
 	matrix = convert_to_adjacency_matrix(matrix)
+
+	# makes sure result[i,j]>0 if i and j belong to the same cluster
+	result = result + result.T
+	
 	m = matrix.sum()
 
 	if isspmatrix(matrix):

--- a/markov_clustering/modularity.py
+++ b/markov_clustering/modularity.py
@@ -1,0 +1,64 @@
+import numpy as np
+from fractions import Fraction
+from scipy.sparse import isspmatrix, dok_matrix, find
+from .mcl import sparse_allclose
+
+def is_undirected(matrix):
+	"""
+	Determine if the matrix reprensents a directed graph
+
+	:param matrix: The matrix to tested
+	:returns: boolean
+	"""
+	if isspmatrix(matrix):
+		return sparse_allclose(matrix, matrix.transpose())
+	
+	return np.allclose(matrix, matrix.T)
+
+
+def convert_to_adjacency_matrix(matrix):
+	"""
+	Converts transition matrix into adjacency matrix
+
+	:param matrix: The matrix to be converted
+	:returns: adjacency matrix
+	"""
+	for i in range(matrix.shape[0]):
+		
+		if isspmatrix(matrix):
+			col = find(matrix[:,i])[2]
+		else:
+			col = matrix[:,i]
+
+		coeff = max( Fraction(c).limit_denominator().denominator for c in col )
+		matrix[:,i] *= coeff
+
+	return matrix
+
+
+def modularity(matrix, result):
+	"""
+	Compute the modularity
+
+	:param matrix: The adjacency matrix
+	:param result: The matrix result of mcl
+	:returns: modularity value
+	"""
+	matrix = convert_to_adjacency_matrix(matrix)
+	m = matrix.sum()
+
+	if isspmatrix(matrix):
+		matrix_2 = matrix.tocsr(copy=True)
+	else :
+		matrix_2 = matrix
+
+	if is_undirected(matrix):
+		expected = lambda i,j : (( matrix_2[i,:].sum() + matrix[:,i].sum() )*
+								 ( matrix[:,j].sum() + matrix_2[j,:].sum() ))
+	else:
+		expected = lambda i,j : ( matrix_2[i,:].sum()*matrix[:,j].sum() )
+	
+	indeces = np.array(result.nonzero())
+	Q = sum( matrix[i, j] - expected(i, j)/m for i, j in indeces.T )/m
+	
+	return Q

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -1,0 +1,225 @@
+import pytest
+import numpy as np
+import markov_clustering as mc
+from scipy.sparse import csc_matrix
+
+test_matrices = [
+    (   # normalize
+        [[1, 1, 0],
+         [0, 1, 1],
+         [0, 0, 1]],
+        
+        [[1, 0.5, 0],
+         [0, 0.5, 0.5],
+         [0, 0,   0.5]]
+    ),
+    (   # inflate
+        [[0.5, 0.5],
+         [1,   1]],
+    
+        [[0.2, 0.2],
+         [0.8, 0.8]]
+    ),
+    (   # expand
+        [[1, 0.5, 0],
+         [0, 0.5, 0.5],
+         [0, 0, 0.5]],
+         
+        [[1, 0.75, 0.25],
+         [0, 0.25, 0.5 ],
+         [0, 0,    0.25]]
+    ),
+    (   # self loops
+        [[0,   0.5, 0],
+         [0,   0,   0.5],
+         [0.5, 0,   0.5]],
+         
+        [[2,   0.5, 0],
+         [0,   2,   0.5],
+         [0.5, 0,   2]]
+    ),
+    (   # prune
+        [[2,   0.5, 0],
+         [0,   2,   0.5],
+         [0.5, 0,   2]],
+    
+        [[2, 0, 0],
+         [0, 2, 0],
+         [0, 0, 2]]
+    ),
+    # converged
+    [[2,   0.5, 0],
+     [0,   2,   0.5],
+     [0.5, 0,   2]],
+    (
+        # iterate
+        [[1, 1, 0],
+         [1, 1, 1],
+         [0, 1, 1]],
+    
+        [[ 0.44444444,  0.23529412,  0.11111111],
+         [ 0.44444444,  0.52941176,  0.44444444],
+         [ 0.11111111,  0.23529412,  0.44444444]]
+    ),
+    (
+        # mcl algorithm
+        [[1, 1, 1, 0, 0, 0, 0],
+         [1, 1, 1, 0, 0, 0, 0],
+         [1, 1, 1, 1, 0, 0, 0],
+         [0, 0, 1, 1, 1, 0, 1],
+         [0, 0, 0, 1, 1, 1, 1],
+         [0, 0, 0, 0, 1, 1, 1],
+         [0, 0, 0, 1, 1, 1, 1]],
+         
+         [[0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0.],
+          [1., 1., 1., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0.5, 0.5, 0.5, 0.5],
+          [0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0.5, 0.5, 0.5, 0.5]]
+    ),
+]
+
+def test_normalize():
+    source = np.matrix(test_matrices[0][0])
+    target = np.matrix(test_matrices[0][1])
+    
+    norm = mc.normalize(source)
+    assert np.array_equal(norm, target)
+
+
+def test_normalize_sparse():
+    source = csc_matrix(test_matrices[0][0])
+    target = np.matrix(test_matrices[0][1])
+    
+    norm = mc.normalize(source).todense()
+    assert np.array_equal(norm, target)
+
+
+def test_inflate():
+    source = np.matrix(test_matrices[1][0])
+    target = np.matrix(test_matrices[1][1])
+    
+    inflated = mc.inflate(source, 2)
+    assert np.array_equal(inflated, target)
+
+
+def test_inflate_sparse():
+    source = csc_matrix(test_matrices[1][0])
+    target = np.matrix(test_matrices[1][1])
+    
+    inflated = mc.inflate(source, 2).todense()
+    assert np.array_equal(inflated, target)
+
+
+def test_expand():
+    source = np.matrix(test_matrices[2][0])
+    target = np.matrix(test_matrices[2][1])
+    
+    expanded = mc.expand(source, 2)
+    assert np.array_equal(expanded, target)
+
+
+def test_expand_sparse():
+    source = csc_matrix(test_matrices[2][0])
+    target = np.matrix(test_matrices[2][1])
+    
+    expanded = mc.expand(source, 2).todense()
+    assert np.array_equal(expanded, target)
+
+
+def test_add_self_loops():
+    source = np.matrix(test_matrices[3][0])
+    target = np.matrix(test_matrices[3][1])
+    
+    looped = mc.add_self_loops(source, 2)
+    assert np.array_equal(looped, target)
+
+
+def test_add_self_loops_sparse():
+    source = csc_matrix(test_matrices[3][0])
+    target = np.matrix(test_matrices[3][1])
+    
+    looped = mc.add_self_loops(source, 2).todense()
+    assert np.array_equal(looped, target)
+
+
+def test_prune():
+    source = np.matrix(test_matrices[4][0])
+    target = np.matrix(test_matrices[4][1])
+    
+    pruned = mc.prune(source, 1)
+    assert np.array_equal(pruned, target)
+
+
+def test_prune_sparse():
+    source = csc_matrix(test_matrices[4][0])
+    target = np.matrix(test_matrices[4][1])
+    
+    pruned = mc.prune(source, 1).todense()
+    assert np.array_equal(pruned, target)
+    
+    
+def test_converged():
+    source = np.matrix(test_matrices[5])
+    assert mc.converged(source, source)
+    
+    source2 = source.copy()
+    source2[0,0] = 2.2
+    assert not mc.converged(source, source2)
+
+
+def test_converged_sparse():
+    source = csc_matrix(test_matrices[5])
+    assert mc.converged(source, source)
+    
+    source2 = source.copy()
+    source2[0,0] = 2.2
+    assert not mc.converged(source, source2)
+    
+
+def test_iterate():
+    source = np.matrix(test_matrices[6][0])
+    target = np.matrix(test_matrices[6][1])
+    
+    iterated = mc.normalize(mc.iterate(source, 2, 2))
+    assert np.array_equal(np.round(iterated, 4), np.round(target, 4))
+
+
+def test_iterate_sparse():
+    source = csc_matrix(test_matrices[6][0])
+    target = np.matrix(test_matrices[6][1])
+    
+    iterated = mc.normalize(mc.iterate(source, 2, 2)).todense()
+    assert np.array_equal(np.round(iterated, 4), np.round(target, 4))
+
+
+def test_mcl():
+    source = np.matrix(test_matrices[7][0])
+    target = np.matrix(test_matrices[7][1])
+    
+    result = mc.run_mcl(source)
+    assert np.array_equal(np.round(result,4), np.round(target, 4))
+
+
+def test_mcl_sparse():
+    source = csc_matrix(test_matrices[7][0])
+    target = np.matrix(test_matrices[7][1])
+    
+    result = mc.run_mcl(source).todense()
+    assert np.array_equal(np.round(result, 4), np.round(target, 4))
+
+
+def test_get_clusters():
+    source = np.matrix(test_matrices[7][1])
+    target = [(0,1,2), (3,4,5,6)]
+    result = mc.get_clusters(source)
+    assert result == target
+
+
+def test_get_clusers_sparse():
+    source = csc_matrix(test_matrices[7][1])
+    target = [(0,1,2), (3,4,5,6)]
+    result = mc.get_clusters(source)
+    assert result == target

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
-import markov_clustering as mc
 from scipy.sparse import csc_matrix
+import markov_clustering as mc
 
 test_matrices = [
     (   # is undirected
@@ -47,7 +47,7 @@ test_matrices = [
          [0  , 0  , 0  , 0  , 1/4, 1/3, 1/4],
          [0  , 0  , 0  , 1/4, 1/4, 1/3, 1/4]],
          
-         -0.8576
+         -284/625
     ),
 ]
 
@@ -55,7 +55,7 @@ def test_is_undirected_1():
     source = np.matrix(test_matrices[0][0])
     target = test_matrices[0][1]
     
-    norm = mc.test_is_undirected(source)
+    norm = mc.is_undirected(source)
     assert norm == target
 
 
@@ -63,7 +63,7 @@ def test_is_undirected_1_sparse():
     source = csc_matrix(test_matrices[0][0])
     target = test_matrices[0][1]
     
-    norm = mc.test_is_undirected(source)
+    norm = mc.is_undirected(source)
     assert norm == target
 
 
@@ -71,7 +71,7 @@ def test_is_undirected_2():
     source = np.matrix(test_matrices[1][0])
     target = test_matrices[1][1]
     
-    norm = mc.test_is_undirected(source)
+    norm = mc.is_undirected(source)
     assert norm == target
 
 
@@ -79,7 +79,7 @@ def test_is_undirected_2_sparse():
     source = csc_matrix(test_matrices[1][0])
     target = test_matrices[1][1]
     
-    norm = mc.test_is_undirected(source)
+    norm = mc.is_undirected(source)
     assert norm == target
 
 
@@ -103,29 +103,31 @@ def test_delta_matrix():
     source = test_matrices[3][0]
     target = np.matrix(test_matrices[3][1])
     
-    converted = mc.delta_matrix(np.matrix(test_matrices[4][0]), source)
-    assert np.array_equal(converted, target)
+    delta = mc.delta_matrix(np.matrix(test_matrices[4][0]), source)
+    assert np.array_equal(delta, target)
 
 
 def test_delta_matrix_sparse():
     source = test_matrices[3][0]
-    target = csc_matrix(test_matrices[3][1])
+    target = np.matrix(test_matrices[3][1])
     
-    converted = mc.delta_matrix( csc_matrix(test_matrices[4][0]) ,source).todense()
-    assert np.array_equal(converted, target)
+    delta = mc.delta_matrix( csc_matrix(test_matrices[4][0]), source).todense()
+    assert np.array_equal(delta, target)
 
 
 def test_modularity():
     source = np.matrix(test_matrices[4][0])
     target = test_matrices[4][1]
-    
-    quality = mc.modularity(source, mc.run_mcl(source))
-    assert quality == target
+    clusters = mc.get_clusters(mc.run_mcl(source))
+
+    quality = mc.modularity(source, clusters)
+    assert np.isclose(quality, target)
 
 
 def test_modularity_sparse():
     source = csc_matrix(test_matrices[4][0])
     target = test_matrices[4][1]
+    clusters = mc.get_clusters(mc.run_mcl(source))
     
-    quality = mc.modularity(source, mc.run_mcl(source))
-    assert quality == target
+    quality = mc.modularity(source, clusters)
+    assert np.isclose(quality, target)

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -4,222 +4,128 @@ import markov_clustering as mc
 from scipy.sparse import csc_matrix
 
 test_matrices = [
-    (   # normalize
+    (   # is undirected
         [[1, 1, 0],
          [0, 1, 1],
          [0, 0, 1]],
         
-        [[1, 0.5, 0],
-         [0, 0.5, 0.5],
-         [0, 0,   0.5]]
+        False
     ),
-    (   # inflate
-        [[0.5, 0.5],
-         [1,   1]],
-    
-        [[0.2, 0.2],
-         [0.8, 0.8]]
-    ),
-    (   # expand
-        [[1, 0.5, 0],
-         [0, 0.5, 0.5],
-         [0, 0, 0.5]],
-         
-        [[1, 0.75, 0.25],
-         [0, 0.25, 0.5 ],
-         [0, 0,    0.25]]
-    ),
-    (   # self loops
-        [[0,   0.5, 0],
-         [0,   0,   0.5],
-         [0.5, 0,   0.5]],
-         
-        [[2,   0.5, 0],
-         [0,   2,   0.5],
-         [0.5, 0,   2]]
-    ),
-    (   # prune
-        [[2,   0.5, 0],
-         [0,   2,   0.5],
-         [0.5, 0,   2]],
-    
-        [[2, 0, 0],
-         [0, 2, 0],
-         [0, 0, 2]]
-    ),
-    # converged
-    [[2,   0.5, 0],
-     [0,   2,   0.5],
-     [0.5, 0,   2]],
-    (
-        # iterate
-        [[1, 1, 0],
-         [1, 1, 1],
+    (   # is undirected
+        [[1, 0, 0],
+         [0, 1, 1],
          [0, 1, 1]],
-    
-        [[ 0.44444444,  0.23529412,  0.11111111],
-         [ 0.44444444,  0.52941176,  0.44444444],
-         [ 0.11111111,  0.23529412,  0.44444444]]
+        
+        True
     ),
-    (
-        # mcl algorithm
-        [[1, 1, 1, 0, 0, 0, 0],
-         [1, 1, 1, 0, 0, 0, 0],
-         [1, 1, 1, 1, 0, 0, 0],
-         [0, 0, 1, 1, 1, 0, 1],
-         [0, 0, 0, 1, 1, 1, 1],
-         [0, 0, 0, 0, 1, 1, 1],
-         [0, 0, 0, 1, 1, 1, 1]],
+    (   # convert to adjacency matrix
+        [[1, 0.5, 0  ],
+         [0, 0.5, 2/3],
+         [0,   0, 1/3]],
          
-         [[0., 0., 0., 0., 0., 0., 0.],
-          [0., 0., 0., 0., 0., 0., 0.],
-          [1., 1., 1., 0., 0., 0., 0.],
-          [0., 0., 0., 0., 0., 0., 0.],
-          [0., 0., 0., 0.5, 0.5, 0.5, 0.5],
-          [0., 0., 0., 0., 0., 0., 0.],
-          [0., 0., 0., 0.5, 0.5, 0.5, 0.5]]
+        [[1, 1, 0],
+         [0, 1, 2],
+         [0, 0, 1]]
+    ),
+    (   # delta matrix
+        [(0,1,2), (3,4,5,6)],
+         
+        [[0, 1, 1, 0, 0, 0, 0],
+         [1, 0, 1, 0, 0, 0, 0],
+         [1, 1, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 1, 1, 1],
+         [0, 0, 0, 1, 0, 1, 1],
+         [0, 0, 0, 1, 1, 0, 1],
+         [0, 0, 0, 1, 1, 1, 0]]
+    ),
+    (   # compute modularity
+        [[1/3, 1/3, 1/4, 0  , 0  , 0  , 0  ],
+         [1/3, 1/3, 1/4, 0  , 0  , 0  , 0  ],
+         [1/3, 1/3, 1/4, 1/4, 0  , 0  , 0  ],
+         [0  , 0  , 1/4, 1/4, 1/4, 0  , 1/4],
+         [0  , 0  , 0  , 1/4, 1/4, 1/3, 1/4],
+         [0  , 0  , 0  , 0  , 1/4, 1/3, 1/4],
+         [0  , 0  , 0  , 1/4, 1/4, 1/3, 1/4]],
+         
+         -0.8576
     ),
 ]
 
-def test_normalize():
+def test_is_undirected_1():
     source = np.matrix(test_matrices[0][0])
-    target = np.matrix(test_matrices[0][1])
+    target = test_matrices[0][1]
     
-    norm = mc.normalize(source)
-    assert np.array_equal(norm, target)
+    norm = mc.test_is_undirected(source)
+    assert norm == target
 
 
-def test_normalize_sparse():
+def test_is_undirected_1_sparse():
     source = csc_matrix(test_matrices[0][0])
-    target = np.matrix(test_matrices[0][1])
+    target = test_matrices[0][1]
     
-    norm = mc.normalize(source).todense()
-    assert np.array_equal(norm, target)
+    norm = mc.test_is_undirected(source)
+    assert norm == target
 
 
-def test_inflate():
+def test_is_undirected_2():
     source = np.matrix(test_matrices[1][0])
-    target = np.matrix(test_matrices[1][1])
+    target = test_matrices[1][1]
     
-    inflated = mc.inflate(source, 2)
-    assert np.array_equal(inflated, target)
+    norm = mc.test_is_undirected(source)
+    assert norm == target
 
 
-def test_inflate_sparse():
+def test_is_undirected_2_sparse():
     source = csc_matrix(test_matrices[1][0])
-    target = np.matrix(test_matrices[1][1])
+    target = test_matrices[1][1]
     
-    inflated = mc.inflate(source, 2).todense()
-    assert np.array_equal(inflated, target)
+    norm = mc.test_is_undirected(source)
+    assert norm == target
 
 
-def test_expand():
+def test_conversion():
     source = np.matrix(test_matrices[2][0])
     target = np.matrix(test_matrices[2][1])
     
-    expanded = mc.expand(source, 2)
-    assert np.array_equal(expanded, target)
+    converted = mc.convert_to_adjacency_matrix(source)
+    assert np.array_equal(converted, target)
 
 
-def test_expand_sparse():
+def test_conversion_sparse():
     source = csc_matrix(test_matrices[2][0])
     target = np.matrix(test_matrices[2][1])
     
-    expanded = mc.expand(source, 2).todense()
-    assert np.array_equal(expanded, target)
+    converted = mc.convert_to_adjacency_matrix(source).todense()
+    assert np.array_equal(converted, target)
 
 
-def test_add_self_loops():
-    source = np.matrix(test_matrices[3][0])
+def test_delta_matrix():
+    source = test_matrices[3][0]
     target = np.matrix(test_matrices[3][1])
     
-    looped = mc.add_self_loops(source, 2)
-    assert np.array_equal(looped, target)
+    converted = mc.delta_matrix(np.matrix(test_matrices[4][0]), source)
+    assert np.array_equal(converted, target)
 
 
-def test_add_self_loops_sparse():
-    source = csc_matrix(test_matrices[3][0])
-    target = np.matrix(test_matrices[3][1])
+def test_delta_matrix_sparse():
+    source = test_matrices[3][0]
+    target = csc_matrix(test_matrices[3][1])
     
-    looped = mc.add_self_loops(source, 2).todense()
-    assert np.array_equal(looped, target)
+    converted = mc.delta_matrix( csc_matrix(test_matrices[4][0]) ,source).todense()
+    assert np.array_equal(converted, target)
 
 
-def test_prune():
+def test_modularity():
     source = np.matrix(test_matrices[4][0])
-    target = np.matrix(test_matrices[4][1])
+    target = test_matrices[4][1]
     
-    pruned = mc.prune(source, 1)
-    assert np.array_equal(pruned, target)
+    quality = mc.modularity(source, mc.run_mcl(source))
+    assert quality == target
 
 
-def test_prune_sparse():
+def test_modularity_sparse():
     source = csc_matrix(test_matrices[4][0])
-    target = np.matrix(test_matrices[4][1])
+    target = test_matrices[4][1]
     
-    pruned = mc.prune(source, 1).todense()
-    assert np.array_equal(pruned, target)
-    
-    
-def test_converged():
-    source = np.matrix(test_matrices[5])
-    assert mc.converged(source, source)
-    
-    source2 = source.copy()
-    source2[0,0] = 2.2
-    assert not mc.converged(source, source2)
-
-
-def test_converged_sparse():
-    source = csc_matrix(test_matrices[5])
-    assert mc.converged(source, source)
-    
-    source2 = source.copy()
-    source2[0,0] = 2.2
-    assert not mc.converged(source, source2)
-    
-
-def test_iterate():
-    source = np.matrix(test_matrices[6][0])
-    target = np.matrix(test_matrices[6][1])
-    
-    iterated = mc.normalize(mc.iterate(source, 2, 2))
-    assert np.array_equal(np.round(iterated, 4), np.round(target, 4))
-
-
-def test_iterate_sparse():
-    source = csc_matrix(test_matrices[6][0])
-    target = np.matrix(test_matrices[6][1])
-    
-    iterated = mc.normalize(mc.iterate(source, 2, 2)).todense()
-    assert np.array_equal(np.round(iterated, 4), np.round(target, 4))
-
-
-def test_mcl():
-    source = np.matrix(test_matrices[7][0])
-    target = np.matrix(test_matrices[7][1])
-    
-    result = mc.run_mcl(source)
-    assert np.array_equal(np.round(result,4), np.round(target, 4))
-
-
-def test_mcl_sparse():
-    source = csc_matrix(test_matrices[7][0])
-    target = np.matrix(test_matrices[7][1])
-    
-    result = mc.run_mcl(source).todense()
-    assert np.array_equal(np.round(result, 4), np.round(target, 4))
-
-
-def test_get_clusters():
-    source = np.matrix(test_matrices[7][1])
-    target = [(0,1,2), (3,4,5,6)]
-    result = mc.get_clusters(source)
-    assert result == target
-
-
-def test_get_clusers_sparse():
-    source = csc_matrix(test_matrices[7][1])
-    target = [(0,1,2), (3,4,5,6)]
-    result = mc.get_clusters(source)
-    assert result == target
+    quality = mc.modularity(source, mc.run_mcl(source))
+    assert quality == target


### PR DESCRIPTION
Addition of the modularity module to compute the quality of the clustering. Giving us the ability to choose the best values for our hyperparametres. Supports both dense and sparse matrices. Implementation in accordance with :
Malliaros, Fragkiskos D., and Michalis Vazirgiannis. "Clustering and community detection in directed networks: A survey." Physics Reports 533.4 (2013): 95-142.

Note that the conversion step is costly and isn't perfect as there is no bijection between adjacency and transition matrices.