### PR TITLE
Support for soft clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Details of the algorithm can be found on the [MCL homepage](https://micans.org/m
 ## Features
 
 - Sparse matrix support
+- Soft clustering support
 - Pruning
 
 ## Requirements

--- a/markov_clustering/mcl.py
+++ b/markov_clustering/mcl.py
@@ -137,7 +137,7 @@ def iterate(matrix, expansion, inflation):
     return matrix
 
 
-def get_clusters(matrix):
+def get_clusters(matrix, keep_overlap=False):
     """
     Retrieve the clusters from the matrix
     
@@ -161,7 +161,32 @@ def get_clusters(matrix):
         cluster = tuple(matrix.getrow(attractor).nonzero()[1].tolist())
         clusters.add(cluster)
 
-    return sorted(list(clusters))
+    # converting it to a list
+    clusters = sorted(list(clusters))
+
+    # checks for overlaping
+    clusters_total_size = sum(len(c) for c in clusters)
+
+    if matrix.shape[0] < clusters_total_size and keep_overlap == False:
+        print('The clustring produced contains overlapping that will be removed, \
+               to unable soft clustring make sure to set keep_overlap to True')
+
+        # set of all nodes
+        nodes = set(range(matrix.shape[0]))
+
+        # remove the overlapping nodes
+        for n, cluster in enumerate(clusters):
+            cluster = set(cluster)
+
+            if not cluster.issubset(nodes):
+                cluster = nodes.intersection(cluster)
+                clusters[n] = tuple(cluster)
+
+            nodes -= cluster
+
+    # getting ride of empty clusters
+    clusters = [c for c in clusters if len(c) > 0]
+    return clusters
 
 
 def run_mcl(matrix, expansion=2, inflation=2, loop_value=1,

--- a/markov_clustering/mcl.py
+++ b/markov_clustering/mcl.py
@@ -186,8 +186,9 @@ def get_clusters(matrix, keep_overlap=False):
 
             nodes -= cluster
 
-    # getting ride of empty clusters
-    clusters = [c for c in clusters if len(c) > 0]
+        # getting ride of empty clusters
+        clusters = [c for c in clusters if len(c) > 0]
+
     return clusters
 
 

--- a/markov_clustering/mcl.py
+++ b/markov_clustering/mcl.py
@@ -142,6 +142,7 @@ def get_clusters(matrix, keep_overlap=False):
     Retrieve the clusters from the matrix
     
     :param matrix: The matrix produced by the MCL algorithm
+    :param keep_overlap: If true, unables soft clustering
     :returns: A list of tuples where each tuple represents a cluster and
               contains the indices of the nodes belonging to the cluster
     """
@@ -168,8 +169,9 @@ def get_clusters(matrix, keep_overlap=False):
     clusters_total_size = sum(len(c) for c in clusters)
 
     if matrix.shape[0] < clusters_total_size and keep_overlap == False:
-        print('The clustering produced contains overlapping that will be removed, \
-               to unable soft clustering make sure to set keep_overlap to True')
+
+        printer = MessagePrinter(True)
+        printer.print("Clustering contains overlapping, to unable soft clustering set keep_overlap to True")
 
         # set of all nodes
         nodes = set(range(matrix.shape[0]))

--- a/markov_clustering/mcl.py
+++ b/markov_clustering/mcl.py
@@ -142,7 +142,7 @@ def get_clusters(matrix, keep_overlap=False):
     Retrieve the clusters from the matrix
     
     :param matrix: The matrix produced by the MCL algorithm
-    :param keep_overlap: If true, unables soft clustering
+    :param keep_overlap: If true, enables soft clustering
     :returns: A list of tuples where each tuple represents a cluster and
               contains the indices of the nodes belonging to the cluster
     """
@@ -171,7 +171,7 @@ def get_clusters(matrix, keep_overlap=False):
     if matrix.shape[0] < clusters_total_size and keep_overlap == False:
 
         printer = MessagePrinter(True)
-        printer.print("Clustering contains overlapping, to unable soft clustering set keep_overlap to True")
+        printer.print("Clustering contains overlapping, to enable soft clustering set keep_overlap to True")
 
         # set of all nodes
         nodes = set(range(matrix.shape[0]))

--- a/markov_clustering/mcl.py
+++ b/markov_clustering/mcl.py
@@ -168,8 +168,8 @@ def get_clusters(matrix, keep_overlap=False):
     clusters_total_size = sum(len(c) for c in clusters)
 
     if matrix.shape[0] < clusters_total_size and keep_overlap == False:
-        print('The clustring produced contains overlapping that will be removed, \
-               to unable soft clustring make sure to set keep_overlap to True')
+        print('The clustering produced contains overlapping that will be removed, \
+               to unable soft clustering make sure to set keep_overlap to True')
 
         # set of all nodes
         nodes = set(range(matrix.shape[0]))

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -223,3 +223,10 @@ def test_get_clusers_sparse():
     target = [(0,1,2), (3,4,5,6)]
     result = mc.get_clusters(source)
     assert result == target
+
+
+def test_delete_overlap():
+    source = (np.matrix(test_matrices[7][1]), [(0,1,2,3), (3,4,5,6)])
+    target = [(0,1,2,3), (4,5,6)]
+    result = mc.delete_overlap(*source)
+    assert result == target


### PR DESCRIPTION
add's the option to keep overlapping nodes in the clustering or to delete their duplicates by setting keep_overlap either to True or False. Displaying a message informing the user that there are overlaps in case he is using the default hard clustering method.